### PR TITLE
Fix optional dependency

### DIFF
--- a/debate_demo.py
+++ b/debate_demo.py
@@ -21,7 +21,12 @@ Multi-Agent Debate - 中文題目 / 中文辯論 版本（官方 SDK，B 強制�
 # 2. 載入套件
 # ------------------------------------------------------------
 import os, openai
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    def load_dotenv(*_args, **_kwargs):
+        """Fallback if python-dotenv isn't installed."""
+        pass
 from autogen import ConversableAgent, GroupChat, GroupChatManager
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- handle missing python-dotenv so script can run without it

## Testing
- `python3 -m py_compile debate_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68418cc2d3b48323a8d246762d64eac1