### PR TITLE
Enable web search tool for Agent B with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ $ python debate_demo.py
 
 The program will print the conversation between Agents A and B, managed by the judge agent, followed by a summary declaring the winner.
 
+## Web Search Preview
+
+Agent B now attempts to use the `web_search_preview` tool to gather up-to-date information while debating. If the search API is unavailable, the script falls back to a normal debate without web results.
+
+Example:
+
+```text
+$ python debate_demo.py
+請輸入辯論題目：人工智慧應該開源嗎？
+(Agent B may show results from a web search.)
+```
+

--- a/debate_demo.py
+++ b/debate_demo.py
@@ -78,7 +78,24 @@ def run_debate(topic: str, rounds: int = 7, model_cfg=None):
 
     # 5‑2. 建立三個代理人
     agent_A = ConversableAgent("A", sys_A, llm_config={"config_list": config_list1}, human_input_mode="NEVER")
-    agent_B = ConversableAgent("B", sys_B, llm_config={"config_list": config_list2}, human_input_mode="NEVER")
+    # Agent B tries to use web_search_preview for up-to-date information.
+    # If the tool fails to initialize, fall back to basic configuration.
+    try:
+        agent_B = ConversableAgent(
+            "B",
+            sys_B,
+            llm_config={
+                "config_list": config_list2,
+                "tools": [{"type": "web_search_preview"}],
+                "tool_choice": "auto",
+            },
+            human_input_mode="NEVER",
+        )
+    except Exception as e:  # pragma: no cover - tool may not be available
+        print(f"[警告] 無法啟用網路搜尋工具：{e}")
+        agent_B = ConversableAgent(
+            "B", sys_B, llm_config={"config_list": config_list2}, human_input_mode="NEVER"
+        )
     judge   = ConversableAgent(
         "Judge", sys_J,
         llm_config={"config_list": config_list3}, human_input_mode="NEVER",


### PR DESCRIPTION
## Summary
- add web_search_preview tool to Agent B
- handle failures when the tool cannot be initialized
- document web search capability in README

## Testing
- `python debate_demo.py <<'EOF'
紅蘋果和青蘋果哪種更營養？
EOF` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6841ab952e308323b123662370a502b9