### PR TITLE
Fix README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,35 @@ pip install -r requirements.txt
 
 ## API Key
 
-Create a `.env` file in the project root with your OpenAI API key:
+Create a `.env` file in the project root with your OpenAI API key. The
+script reads this value at runtime, so the file must be present:
 
 ```bash
 echo "OPENAI_API_KEY=sk-your-key" > .env
 ```
 
-Make sure the key is valid before running the demo.
+Make sure the key is valid before running the demo. If needed you can
+install the dependencies manually with `pip install "pyautogen[openai]" python-dotenv -q`.
+The provided `requirements.txt` uses the renamed `autogen-agentchat` package.
 
 ## Usage
 
 Run the demo script and follow the prompt to enter a debate topic:
 
 ```bash
-python debate_demo.py
+python multi_agent_debate.py
 ```
 
 Example interaction:
 
 ```text
-$ python debate_demo.py
+$ python multi_agent_debate.py
 請輸入辯論題目：人工智慧應該開源嗎？
 ```
 
 The program will print the conversation between Agents A and B, managed by the judge agent, followed by a summary declaring the winner.
+By default the script runs a total of 17 rounds (including the judge's final statement),
+but you can change this by passing the `rounds` argument to `run_debate()`.
 
 ## Web Search Preview
 
@@ -44,8 +49,12 @@ Agent B now attempts to use the `web_search_preview` tool to gather up-to-date i
 Example:
 
 ```text
-$ python debate_demo.py
+$ python multi_agent_debate.py
 請輸入辯論題目：人工智慧應該開源嗎？
 (Agent B may show results from a web search.)
 ```
+
+The script defaults to the `gpt-4o` and `gpt-4.1` model names. If these models
+are unavailable to your account, edit `multi_agent_debate.py` and adjust the
+`config_list1`–`config_list3` settings accordingly.
 


### PR DESCRIPTION
## Summary
- reference `multi_agent_debate.py` instead of the removed `debate_demo.py`
- explain the `.env` requirement and add notes on installing packages
- clarify default debate rounds and how to change them
- show how to update model names if needed

## Testing
- `python -m py_compile multi_agent_debate.py`

------
https://chatgpt.com/codex/tasks/task_e_68425fe5cf788323b4ca8b97510b7611